### PR TITLE
Fix memory-issue in `buildmolecules.py`

### DIFF
--- a/src/blr/cli/buildmolecules.py
+++ b/src/blr/cli/buildmolecules.py
@@ -220,7 +220,7 @@ class AllMolecules:
         Check if overlap between current read and those in the molecule are acceptable.
         """
         molecule = self.molecule_cache[barcode]
-        return molecule.has_acceptable_overlap(read, self.tn5, summary):
+        return molecule.has_acceptable_overlap(read, self.tn5, summary)
 
     def read_is_in_window(self, read, barcode):
         """


### PR DESCRIPTION
@marcelm noted that `buildmolecules.py` used quite a considerable amount of memory, this is PR trying to minimise memory usage for the script. I also did some factoring out parts of the `build_molecules` function and did other fixes and style changes.

The main improvements are:
- The `cache_dict` object (now called `molecules_cache`) stored all `Molecule` instances and was only cleared for each chromosome. I now implemented an  `OrderedDict` to keep track of the stored molecules add report and remove any that are outside the current window. 
- The `bc_to_mol_dict` stored a set of full `Molecule` instances for each barcode. I changed this so that a list of dicts containing only the required information are kept. 
- I also fixed the sharp memory peak in the end (see figure) caused by the generation of molecules statistics. 

This seams to have helped somewhat as you can see from the figures below (run on chr22). The peak memory use is now down about ~55%.  

I have done several testruns on chr22 to confirm that the output is the same. The only difference is the order of the columns in the `molecule_stats.tsv` where the column "NrMolecules" has moved to the end. 

![image](https://user-images.githubusercontent.com/27061883/83521011-e16e0400-a4de-11ea-9ee0-486f9b099ef0.png)
**Figure 1:** Profile for `master`, generated using psrecord.

![image](https://user-images.githubusercontent.com/27061883/83528593-93123280-a4e9-11ea-9044-bfc3b4785496.png)
**Figure 2:** Profile for `buildmol-memfix`, generated using psrecord. 