### PR TITLE
Switch to using a multi-chromosome test dataset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           flake8 --select=W292 environment.yml
       - name: Download test dataset
         env:
-          testdata_version: "0.3.1"
+          testdata_version: "0.4.2"
         run: |
           wget -nv https://export.uppmax.uu.se/uppstore2018173/blr-testdata-${testdata_version}.tar.gz
           tar xf blr-testdata-${testdata_version}.tar.gz

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -19,10 +19,10 @@ else
 fi
 
 pushd blr-testdata
-bwa index chr1mini.fasta
-bowtie2-build chr1mini.fasta chr1mini.fasta > /dev/null
-samtools faidx chr1mini.fasta
-test -f chr1mini.dict || gatk CreateSequenceDictionary -R chr1mini.fasta
+bwa index ref.fasta
+bowtie2-build ref.fasta ref.fasta > /dev/null
+samtools faidx ref.fasta
+test -f ref.dict || gatk CreateSequenceDictionary -R ref.fasta
 popd
 
 pytest -v tests/
@@ -32,18 +32,18 @@ rm -rf outdir-bowtie2
 blr init --r1=blr-testdata/blr_reads.1.fastq.gz -l blr outdir-bowtie2
 blr config \
     --file outdir-bowtie2/blr.yaml \
-    --set genome_reference ../blr-testdata/chr1mini.fasta \
-    --set dbSNP ../blr-testdata/dbSNP.chr1mini.vcf.gz \
-    --set reference_variants ../blr-testdata/HG002_GRCh38_GIAB_highconf.chr1mini.vcf \
-    --set phasing_ground_truth ../blr-testdata/HG002_GRCh38_GIAB_highconf_triophased.chr1mini.vcf \
+    --set genome_reference ../blr-testdata/ref.fasta \
+    --set dbSNP ../blr-testdata/dbSNP.vcf.gz \
+    --set reference_variants ../blr-testdata/HG002_GRCh38_GIAB_highconf.vcf \
+    --set phasing_ground_truth ../blr-testdata/HG002_GRCh38_GIAB_highconf_triophased.vcf \
     --set max_molecules_per_bc 1 \
     --set heap_space 1
 
 cd outdir-bowtie2
 blr run
 m=$(samtools view mapped.sorted.tag.bcmerge.mkdup.mol.filt.bam | $md5 | cut -f1 -d" ")
-test $m == b7c6fc6489dc59dd72e985ef8522e2e1
+test $m == 96f8a86cdcf6f8a808fd66b9353f779e
 
 # Cut away columns 2 and 3 as these change order between linux and osx
 m2=$(cut -f1,4- mapped.calling.phase | $md5 | cut -f1 -d" ")
-test $m2 == e6c512bfeb7cb1b230a9320f22c32937
+test $m2 == d41d8cd98f00b204e9800998ecf8427e

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,9 +20,9 @@ TESTDATA_STLFR_READ1 = TESTDATA / "stlfr_reads.1.fastq.gz"
 TESTDATA_STLFR_READ2 = TESTDATA / "stlfr_reads.2.fastq.gz"
 TESTDATA_STLFR_BARCODES = str((TESTDATA / "stlfr_barcodes.txt").absolute())
 DEFAULT_CONFIG = "blr.yaml"
-REFERENCE_GENOME = str((TESTDATA / "chr1mini.fasta").absolute())
-REFERENCE_VARIANTS = str((TESTDATA / "HG002_GRCh38_GIAB_highconf.chr1mini.vcf").absolute())
-DB_SNP = str((TESTDATA / "dbSNP.chr1mini.vcf.gz").absolute())
+REFERENCE_GENOME = str((TESTDATA / "ref.fasta").absolute())
+REFERENCE_VARIANTS = str((TESTDATA / "HG002_GRCh38_GIAB_highconf.vcf").absolute())
+DB_SNP = str((TESTDATA / "dbSNP.vcf.gz").absolute())
 
 
 def count_bam_alignments(path):


### PR DESCRIPTION
This test dataset contains multiple chromosomes and is therefore suitable for testing splitting by chromosome. This branches off the `tests` branch, so it’ll need rebasing once #12 is merged.