### PR TITLE
Compute phasing stats even when we call our own variants

### DIFF
--- a/src/blr/Snakefile
+++ b/src/blr/Snakefile
@@ -31,7 +31,7 @@ def get_final_targets(wildcards):
         "multiqc_report.html",
         "mapped.calling.bam",
     ]
-    if config["reference_variants"] and config["phasing_ground_truth"]:
+    if config["phasing_ground_truth"]:
         input_files.append("mapped.phasing_stats.txt")
 
     return input_files
@@ -64,7 +64,7 @@ def get_multiqc_input(wildcards):
         "mapped.sorted.tag.bcmerge.mkdup.mol.filt.bam",
         "figures/mapped",
     ]
-    if config["reference_variants"] and config["phasing_ground_truth"]:
+    if config["phasing_ground_truth"]:
         inputs.append("mapped.phasing_stats.tsv")
 
     return inputs


### PR DESCRIPTION
I’m opening this small PR to ensure I’m not overlooking something.

The `mapped.phasing_stats.(txt|tsv)` files are currently only computed when the user has supplied both a ground-truth VCF *and* a ready-made VCF that contains already called variants (that is, when we don’t do our own variant calling).

However, I would think that we want to compute those stats even if we call our own variants, as long as the ground truth VCF is available.