### PR TITLE
Disable tqdm if directing stderr to file.

### DIFF
--- a/src/blr/cli/buildmolecules.py
+++ b/src/blr/cli/buildmolecules.py
@@ -8,11 +8,10 @@ a maximum distance of --window between any given reads.
 import pysam
 import logging
 from collections import Counter, OrderedDict, defaultdict
-from tqdm import tqdm
 import pandas as pd
 import statistics
 
-from blr.utils import PySAMIO, get_bamtag, print_stats, calculate_N50
+from blr.utils import PySAMIO, get_bamtag, print_stats, calculate_N50, tqdm
 
 logger = logging.getLogger(__name__)
 

--- a/src/blr/cli/clusterrmdup.py
+++ b/src/blr/cli/clusterrmdup.py
@@ -11,10 +11,9 @@ sharing more than one barcode (share = union(bc_set_pos1, bc_set_pos2)).
 
 import pysam
 import logging
-from tqdm import tqdm
 from collections import Counter, deque, OrderedDict
 
-from blr.utils import PySAMIO, get_bamtag, print_stats
+from blr.utils import PySAMIO, get_bamtag, print_stats, tqdm
 
 logger = logging.getLogger(__name__)
 

--- a/src/blr/cli/filterclusters.py
+++ b/src/blr/cli/filterclusters.py
@@ -5,9 +5,8 @@ which had more than -M molecules in one and the same droplet).
 
 import logging
 from collections import Counter
-from tqdm import tqdm
 
-from blr.utils import get_bamtag, PySAMIO, print_stats
+from blr.utils import get_bamtag, PySAMIO, print_stats, tqdm
 
 logger = logging.getLogger(__name__)
 
@@ -17,7 +16,6 @@ def main(args):
     removed_tags = {tag: set() for tag in tags_to_remove}
     summary = Counter()
     logger.info("Starting")
-
     # Writes filtered out
     with PySAMIO(args.input, args.output, __name__) as (openin, openout):
         for read in tqdm(openin.fetch(until_eof=True), desc="Filtering input", unit="reads"):

--- a/src/blr/cli/phasebam.py
+++ b/src/blr/cli/phasebam.py
@@ -13,10 +13,9 @@ Outputs:
 
 import pysam
 import logging
-from tqdm import tqdm
 from collections import Counter, OrderedDict
 
-from blr.utils import print_stats, get_bamtag, PySAMIO
+from blr.utils import print_stats, get_bamtag, PySAMIO, tqdm
 
 logger = logging.getLogger(__name__)
 

--- a/src/blr/cli/tagbam.py
+++ b/src/blr/cli/tagbam.py
@@ -3,10 +3,10 @@ Strips headers from tags and depending on mode, set the appropriate SAM tag.
 """
 
 import logging
-from tqdm import tqdm
 from collections import Counter
 from pathlib import Path
-from blr.utils import print_stats, PySAMIO, get_bamtag
+
+from blr.utils import print_stats, PySAMIO, get_bamtag, tqdm
 from blr.cli.config import load_yaml
 
 logger = logging.getLogger(__name__)

--- a/src/blr/cli/tagfastq.py
+++ b/src/blr/cli/tagfastq.py
@@ -22,7 +22,7 @@ import logging
 import sys
 import dnaio
 from itertools import islice
-from tqdm import tqdm
+from blr.utils import tqdm
 
 logger = logging.getLogger(__name__)
 

--- a/src/blr/utils.py
+++ b/src/blr/utils.py
@@ -4,6 +4,12 @@ import sys
 import pysam
 import numpy as np
 
+if sys.stderr.isatty():
+    from tqdm import tqdm
+else:
+    def tqdm(iterable, **kwargs):
+        return iterable
+
 
 def is_1_2(s, t):
     """


### PR DESCRIPTION
Fix for https://github.com/FrickTobias/BLR/issues/209. 

`tqdm` is now imported from `blr.utils` which return a custom function is stderr is directed to a file. 