### PR TITLE
Manage the version number with setuptools_scm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ __pycache__/
 /src/blr.egg-info/
 
 .idea/
+/src/blr/_version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,5 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
+
+[tool.setuptools_scm]
+write_to = "src/blr/_version.py"

--- a/src/blr/__init__.py
+++ b/src/blr/__init__.py
@@ -1,0 +1,3 @@
+__all__ = ["__version__"]
+
+from ._version import version as __version__

--- a/src/blr/__main__.py
+++ b/src/blr/__main__.py
@@ -8,15 +8,15 @@ import importlib
 from argparse import ArgumentParser
 
 import blr.cli as cli_package
-
+from blr import __version__
 
 logger = logging.getLogger(__name__)
 
 
-def main() -> int:
+def main(commandline_arguments=None) -> int:
     logging.basicConfig(level=logging.INFO, format="%(module)s - %(levelname)s: %(message)s")
     parser = ArgumentParser(description=__doc__, prog="blr")
-    parser.add_argument("--version", action="version", version="%(prog)s 0.1")
+    parser.add_argument("--version", action="version", version=__version__)
     subparsers = parser.add_subparsers()
 
     # Import each module that implements a subcommand and add a subparser for it.
@@ -30,7 +30,7 @@ def main() -> int:
         subparser.set_defaults(module=module)
         module.add_arguments(subparser)
 
-    args = parser.parse_args()
+    args = parser.parse_args(commandline_arguments)
     if not hasattr(args, "module"):
         parser.error("Please provide the name of a subcommand to run")
     else:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,6 +4,7 @@ import pysam
 import pytest
 import dnaio
 
+from blr.__main__ import main as blr_main
 from blr.cli.init import init
 from blr.cli.run import run
 from blr.cli.config import change_config
@@ -200,3 +201,9 @@ def test_haplotag(workdir, haplotype_tool):
     assert bam_has_tag(workdir / target, "HP")
     assert bam_has_tag(workdir / target, "PS")
     assert count_bam_tags(workdir / target, "PS") == count_bam_tags(workdir / target, "HP")
+
+
+def test_version_exit_code_zero():
+    with pytest.raises(SystemExit) as e:
+        blr_main(["--version"])
+    assert e.value.code == 0


### PR DESCRIPTION
With this, the version number is obtained from the most recent Git tag. It works in the following way.

* When the current HEAD has tag `v3.141`, `blr --version` prints 3.141.
* If the most recent tag is `v3.141`, but 5 extra commits have been made since then, the output is `v3.142.dev5+ged3560f` (the minor version is incremented, the `dev5` part describes the number of commits since the most recent tag, and the string after `+g` is the HEAD commit hash.)
* If local, uncommitted changes exist, the current date is appended to the version number, as in `.d20200616`.

I also highly recommend to tag a version number soon.