### PR TITLE
Add version number to blr log files and to SAM headers.

### DIFF
--- a/src/blr/__main__.py
+++ b/src/blr/__main__.py
@@ -38,7 +38,7 @@ def main(commandline_arguments=None) -> int:
         del args.module
 
         # Print settings for module
-        sys.stderr.write(f"SETTINGS FOR: {module.__name__.split('.')[-1]}\n")
+        sys.stderr.write(f"SETTINGS FOR: {module.__name__.split('.')[-1]} (version: {__version__})\n")
         for object_variable, value in vars(args).items():
             sys.stderr.write(f" {object_variable}: {value}\n")
 

--- a/src/blr/utils.py
+++ b/src/blr/utils.py
@@ -4,6 +4,8 @@ import sys
 import pysam
 import numpy as np
 
+from blr import __version__
+
 if sys.stderr.isatty():
     from tqdm import tqdm
 else:
@@ -146,11 +148,11 @@ class PySAMIO:
         # Make sure id_name is unique by adding numbers at end if needed.
         id_name = make_unique(id_name, pg_entries)
 
-        # TODO add version information (VN tag).
         pg_entries.append({
             "ID": id_name,       # Program record identifier. Must be unique
             "PN": program_name,  # Program name
-            "CL": cmd_line       # Command line arguments string.
+            "CL": cmd_line,      # Command line arguments string.
+            "VN": __version__    # Version information
         })
         header["PG"] = pg_entries
 


### PR DESCRIPTION
This PR adds the version tag to log files and to SAM headers. See below for examples.

**Log files**

<pre>
$ cat tag_fastq.log 
SETTINGS FOR: tagfastq <b>(version: 0.2.dev26+gde2c535)</b>
 uncorrected_barcodes: barcodes.fasta.gz
 corrected_barcodes: barcodes.clstr
 input1: trimmed.fastq
 input2: None
 output1: trimmed.barcoded.1.fastq.gz
 output2: trimmed.barcoded.2.fastq.gz
 barcode_tag: BX
 sequence_tag: RX
 mapper: bowtie2
. . .
</pre>
**SAM header**
<pre>
$ samtools view -H mapped.sorted.tag.bam
@HD	VN:1.0	SO:coordinate
@SQ	SN:chrA	LN:50000
@SQ	SN:chrB	LN:40000
@SQ	SN:chrC	LN:9000
@SQ	SN:chrD	LN:1000
@RG	ID:1	SM:20	LB:blr	PU:unit1	PL:ILLUMINA
@PG	PN:bowtie2	ID:bowtie2	VN:2.3.5.1	CL:"/Users/pontus.hojer/miniconda3/envs/blr/bin/bowtie2-align-s --wrapper basic-0 -p 4 --rg-id 1 --rg LB:blr --rg SM:20 --rg PU:unit1 --rg PL:ILLUMINA --reorder --maxins 2000 -x ../blr-testdata/ref.fasta -1 trimmed.barcoded.1.fastq.gz -2 trimmed.barcoded.2.fastq.gz"
@PG	PN:blr	ID:tagbam	<b>VN:0.2.dev26+gde2c535</b>	CL:"/Users/pontus.hojer/miniconda3/envs/blr/bin/blr tagbam mapped.sorted.bam -o mapped.sorted.tag.bam"
</pre>