### PR TITLE
Add window_size as parameter in configs

### DIFF
--- a/src/blr/Snakefile
+++ b/src/blr/Snakefile
@@ -301,6 +301,7 @@ rule buildmolecules:
         " -m {config[molecule_tag]}"
         " -n {config[num_mol_tag]}"
         " -b {config[cluster_tag]}"
+        " --window {config[window_size]}"
         " 2> {log}"
 
 

--- a/src/blr/blr.yaml
+++ b/src/blr/blr.yaml
@@ -48,3 +48,4 @@ heap_space: 90 # GATK: Maximum heap space (~memory) to run java script with, as 
 barcode_max_dist: 2 # blr: Max edit distance (Leveshtein distance) allowed to cluster two barcode sequences together
 barcode_ratio: 5 # starcode: Minimum difference in ratio for read count to cluster nodes
 max_molecules_per_bc: 260 # blr: Max number of molecules allowed for a single barcode (removes if bc has > 260 molecules).
+window_size: 30000 # blr: Window size used for linking reads by barcodes.

--- a/src/blr/config.schema.yaml
+++ b/src/blr/config.schema.yaml
@@ -98,3 +98,7 @@ properties:
     type: integer
     default: 20000000
     description: Chunk size for parallelization
+  window_size:
+    type: integer
+    default: 30000
+    description: Window size used for linking reads by barcodes.

--- a/src/blr/rules/phasing.smk
+++ b/src/blr/rules/phasing.smk
@@ -34,7 +34,8 @@ rule hapcut2_linkfragments:
         " --bam {input.bam}"
         " -v {input.vcf}"
         " --fragments {input.unlinked}"
-        " --out {output.linked} &> {log}"
+        " --out {output.linked}"
+        " --distance {config[window_size]} &> {log}"
 
 
 rule hapcut2_phasing:
@@ -110,7 +111,7 @@ rule haplotag:
                 " {input.vcf}"
                 " {input.bam}"
                 " -o {output.bam}"
-                " --linked-read-distance-cutoff 30000"
+                " --linked-read-distance-cutoff {config[window_size]}"
                 " --reference {config[genome_reference]}",
             "blr":
                 "blr phasebam"


### PR DESCRIPTION
Currently default values are defined by the programs while they should be the same for all. This does not change the default value except for LinkFragments which had an old default of 20,000 bp (default is 30,000 bp so more variants should now be included for phasing.   