### PR TITLE
Change flag for collecting unmapped reads.

### DIFF
--- a/src/blr/Snakefile
+++ b/src/blr/Snakefile
@@ -232,7 +232,7 @@ rule get_unmapped_reads:
         bam = "initialmapping.bam"
     log: "unmapped.log"
     shell:
-        "samtools view -hf 4 {input.bam} | blr tagbam -o {output.bam} - 2> {log}"
+        "samtools view -hf 13 {input.bam} | blr tagbam -o {output.bam} - 2> {log}"
 
 
 # TODO The input BAMs for tagbam could be created on-the-fly (in a pipe)

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -43,7 +43,7 @@ blr config \
 cd outdir-bowtie2
 blr run
 m=$(samtools view final.bam | $md5 | cut -f1 -d" ")
-test $m == 26a5649edcc722c9fd762829282fe767
+test $m == 84e10c451785a2eded1ffd785db5c1cc
 
 # Cut away columns 2 and 3 as these change order between linux and osx
 m2=$(grep -v "^##" final.phased.vcf | $md5 | cut -f1 -d" ")


### PR DESCRIPTION
`samtools view - f 4` collects all unmapped which includes some assigned to the chunks. Apparently it the mate of a read is mapped it gets assigned to the same chromosome. This results is some duplicates entries after merging and also makes the `final.bam` no longer sorted. `samtools view - f 13` instead filters for reads where both the mate and read are unmapped. 