### PR TITLE
Update blr run command

### DIFF
--- a/src/blr/cli/run.py
+++ b/src/blr/cli/run.py
@@ -59,7 +59,7 @@ def main(args):
             force_run=args.force_run,
             printdag=args.dag,
             printfilegraph=args.filegraph,
-            targets=args.targets)
+            targets=targets)
     except SnakemakeError:
         sys.exit(1)
     sys.exit(0)


### PR DESCRIPTION
Include new arguments `--delete-all-output` and `--force-run/-R`.
All available cores are now used as default.  