### PR TITLE
update concat_molecule_stats

### DIFF
--- a/src/blr/Snakefile
+++ b/src/blr/Snakefile
@@ -327,9 +327,9 @@ rule concat_molecule_stats:
                 df = pd.read_csv(file, sep="\t")
             except pd.errors.EmptyDataError:
                 continue
-            if not df.empty:
-                df["ChunkID"] = nr
-                dfs.append(df)
+
+            df["ChunkID"] = nr
+            dfs.append(df)
 
         concat = pd.concat(dfs, ignore_index=True)
         concat.to_csv(output.tsv, sep="\t", index=False)


### PR DESCRIPTION
Pandas raises error when a file is empty, adding try-except.