### PR TITLE
Update testdata to version 0.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Download test dataset
         shell: bash -l {0}
         env:
-          testdata_version: "0.5"
+          testdata_version: "0.6"
         run: |
           wget -nv https://export.uppmax.uu.se/uppstore2018173/blr-testdata-${testdata_version}.tar.gz
           tar xf blr-testdata-${testdata_version}.tar.gz

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Download test dataset
         shell: bash -l {0}
         env:
-          testdata_version: "0.5"
+          testdata_version: "0.6"
         run: |
           wget -nv https://export.uppmax.uu.se/uppstore2018173/blr-testdata-${testdata_version}.tar.gz
           tar xf blr-testdata-${testdata_version}.tar.gz

--- a/README.md
+++ b/README.md
@@ -62,15 +62,16 @@ For more options, see the documentation.
 
 For unit testing we use test files for different platforms. The latest version of these can be downloaded and unpacked using the following commands:
 
-    wget -nv https://export.uppmax.uu.se/uppstore2018173/blr-testdata-0.5.tar.gz
-    tar xf blr-testdata-0.5.tar.gz
-    ln -s blr-testdata-0.5 blr-testdata
+    wget -nv https://export.uppmax.uu.se/uppstore2018173/blr-testdata-0.6.tar.gz
+    tar xf blr-testdata-0.6.tar.gz
+    ln -s blr-testdata-0.6 blr-testdata
 
 Now unit testing can be run locally from within the BLR directory using:
 
     bash tests/run.sh
 
-This is useful if you want to test your changes before submitting them as a PR.
+This is useful if you want to test your changes localy before submitting them
+ as a PR.
 
 ### 4. Merging different analysis runs
 

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -30,13 +30,13 @@ pytest -v tests/
 
 # Test full run on BLR library.
 rm -rf outdir-bowtie2
-blr init --r1=blr-testdata/blr_reads.1.fastq.gz -l dbs outdir-bowtie2
+blr init --r1=blr-testdata/dbs_reads.1.fastq.gz -l dbs outdir-bowtie2
 blr config \
     --file outdir-bowtie2/blr.yaml \
     --set genome_reference ../blr-testdata/ref.fasta \
     --set dbSNP ../blr-testdata/dbSNP.vcf.gz \
-    --set reference_variants ../blr-testdata/HG002_GRCh38_GIAB_highconf.vcf \
-    --set phasing_ground_truth ../blr-testdata/HG002_GRCh38_GIAB_highconf_triophased.vcf \
+    --set reference_variants ../blr-testdata/HG002_GRCh38_GIAB_highconf.vcf.gz \
+    --set phasing_ground_truth ../blr-testdata/HG002_GRCh38_GIAB_highconf_triophased.vcf.gz \
     --set max_molecules_per_bc 1 \
     --set heap_space 1 \
     --set chunk_size 10000 \
@@ -46,4 +46,4 @@ blr config \
 cd outdir-bowtie2
 blr run
 m=$(samtools view final.bam | $md5 | cut -f1 -d" ")
-test $m == 94a546d0c54e90a64a6dbdb58f4acc1f
+test $m == 13f08e596232d44660ac337606f87279


### PR DESCRIPTION
- Fix https://github.com/FrickTobias/BLR/issues/207 by making testdata generation fully reproducible
- Rename `blr_reads.?.fastq.gz` --> `dbs_reads.?.fastq.gz`
- Reduce size of test FASTQs from ~10k to 1k read pairs to speed up tests.  