### PR TITLE
Reduce number of scheduled CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on: 
   pull_request:
   schedule:
-    - cron: 0 7 * * 1,3,5
+    - cron: 0 7 10 * *
 
 jobs:
   Linting:


### PR DESCRIPTION
The NBISweden organization has a limited amount of CI minutes. To save some of them, I’d like to change scheduled CI runs from three times a week to once every month.