### PR TITLE
Run macOS CI tests only on request

### DIFF
--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -1,8 +1,7 @@
 name: CI macos
 
-on: 
-  schedule:
-    - cron: 0 8 7 * *
+on:
+  workflow_dispatch:
 
 jobs:
   Linting:


### PR DESCRIPTION
The scheduled macOS CI job has been failing for a couple of weeks, so it seems these tests are not used. To save GitHub Actions minutes, I’d like to switch from scheduled runs every month to running only on demand.