### PR TITLE
Do not lint on macOS

### DIFF
--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -5,26 +5,7 @@ on:
     - cron: 0 8 7 * *
 
 jobs:
-  Linting:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup Python
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.6
-          architecture: x64
-      - name: Install flake8
-        run:
-          pip install flake8
-      - name: Run flake8
-        run:
-          flake8 src/ tests/
-          flake8 --select=W292 --filename '*.yaml,*.yml'
-
   Testing:
-    needs:
-      - Linting
     name: Run pipeline
     timeout-minutes: 20
     runs-on: macos-latest


### PR DESCRIPTION
To save (a tiny amount of) CI minutes, do not lint on macOS.